### PR TITLE
fix. BLS G1 order

### DIFF
--- a/cmd/etherfi/createBLS.go
+++ b/cmd/etherfi/createBLS.go
@@ -62,10 +62,12 @@ func createBLS(ctx context.Context, cli *cli.Command) error {
 	sig := new(types.AVSBLSSignature)
 	sig.G1.X = keyPair.GetPubKeyG1().X.String()
 	sig.G1.Y = keyPair.GetPubKeyG1().Y.String()
-	sig.G2.X[0] = keyPair.GetPubKeyG2().X.A0.String()
-	sig.G2.X[1] = keyPair.GetPubKeyG2().X.A1.String()
-	sig.G2.Y[0] = keyPair.GetPubKeyG2().Y.A0.String()
-	sig.G2.Y[1] = keyPair.GetPubKeyG2().Y.A1.String()
+
+	sig.G2.X[1] = keyPair.GetPubKeyG2().X.A0.String()
+	sig.G2.X[0] = keyPair.GetPubKeyG2().X.A1.String()
+	sig.G2.Y[1] = keyPair.GetPubKeyG2().Y.A0.String()
+	sig.G2.Y[0] = keyPair.GetPubKeyG2().Y.A1.String()
+
 	sig.Signature.X = signature.X.String()
 	sig.Signature.Y = signature.Y.String()
 


### PR DESCRIPTION
Previous [PR](https://github.com/etherfi-protocol/etherfi-avs-operator-CLI/commit/b09ccccb6ea473f63e1138f2147218d3c8c68b4b#diff-38b9ef48ef13a71d5571e82810524c9d0de4a9f5e24bd73c920926cd1e45aa20R65) overlapped fixes of BLS signature order by fault.

