### PR TITLE
Lagrange Fix + Stakedrop address + check registration status

### DIFF
--- a/bin/avs-cli/main.go
+++ b/bin/avs-cli/main.go
@@ -33,6 +33,8 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			BlsPubkeyRegistrationHashCmd,
+			RegistrationStatusCmd,
+			StakedropAddressCmd,
 			operatorDetailsCmd,
 			updateEcdsaSignerCmd,
 

--- a/bin/avs-cli/registration_status.go
+++ b/bin/avs-cli/registration_status.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/config"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/eigenlayer"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/etherfi"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v3"
+)
+
+var RegistrationStatusCmd = &cli.Command{
+	Name:   "registration-status",
+	Usage:  "check which AVSs a target operator is registered for (from the perspective of eigenlayer)",
+	Action: handleRegistrationStatus,
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:     "operator-id",
+			Usage:    "Operator ID",
+			Required: true,
+		},
+	},
+}
+
+func handleRegistrationStatus(ctx context.Context, cmd *cli.Command) error {
+
+	// parse cli input
+	operatorID := cmd.Int("operator-id")
+
+	// try to load RPC_URL from env or flags
+	rpcURL := os.Getenv("RPC_URL")
+	if cmd.String("rpc-url") != "" {
+		rpcURL = cmd.String("rpc-url")
+	}
+	if rpcURL == "" {
+		return fmt.Errorf("must set env var $RPC_URL or use --rpc-url flag")
+	}
+	rpcClient, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		return fmt.Errorf("dialing RPC: %w", err)
+	}
+
+	// load all required addresses for this chain
+	cfg, err := config.AutodetectConfig(rpcClient)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	etherfiAPI := etherfi.New(cfg, rpcClient)
+
+	// look up operator contract associated with this id
+	operator, err := etherfiAPI.LookupOperatorByID(operatorID)
+	if err != nil {
+		return fmt.Errorf("looking up operator address: %w", err)
+	}
+
+	type AVS struct {
+		Name           string
+		ServiceManager common.Address
+	}
+	activeAVSs := []AVS{
+		{Name: "AltLayer", ServiceManager: cfg.AltLayerServiceManagerAddress},
+		{Name: "ARPA", ServiceManager: cfg.ARPAServiceManagerAddress},
+		//		{Name: "ARPA", ServiceManager: cfg.ARPANodeRegistryAddress},
+		{Name: "Automata", ServiceManager: cfg.AutomataServiceManagerAddress},
+		{Name: "Brevis", ServiceManager: cfg.BrevisServiceManagerAddress},
+		{Name: "CyberMACH", ServiceManager: cfg.CyberMachServiceManagerAddress},
+		{Name: "EigenDA", ServiceManager: cfg.EigenDAServiceManagerAddress},
+		{Name: "eOracle", ServiceManager: cfg.EOracleServiceManagerAddress},
+		{Name: "Hyperlane", ServiceManager: cfg.HyperlaneServiceManagerAddress},
+		{Name: "LagrangeSC", ServiceManager: cfg.LagrangeServiceAddress},
+		{Name: "LagrangeZK", ServiceManager: cfg.LagrangeZKMRServiceManagerAddress},
+		{Name: "Openlayer", ServiceManager: cfg.OpenlayerServiceManagerAddress},
+		{Name: "Witnesschain", ServiceManager: cfg.WitnessChainWitnessHubAddress},
+	}
+
+	avsDirectory, err := eigenlayer.NewAvsDirectory(cfg.AvsDirectoryAddress, rpcClient)
+	if err != nil {
+		return fmt.Errorf("binding AVSDirectory contract: %w", err)
+	}
+
+	greenText := color.New(color.FgHiGreen)
+	redText := color.New(color.FgHiRed)
+
+	for _, avs := range activeAVSs {
+		status, err := avsDirectory.AvsOperatorStatus(nil, avs.ServiceManager, operator.Address)
+		if err != nil {
+			return fmt.Errorf("fetching operator status: %w", err)
+		}
+		fmt.Printf("%s %s\n", avs.ServiceManager, operator.Address)
+
+		fmt.Printf("%s: ", avs.Name)
+		if status == 1 {
+			greenText.Printf("Registered\n")
+		} else {
+			redText.Printf("Unregistered\n")
+		}
+
+	}
+
+	return nil
+}

--- a/bin/avs-cli/stakedrop_address.go
+++ b/bin/avs-cli/stakedrop_address.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/config"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/eigenlayer"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/etherfi"
+	"github.com/urfave/cli/v3"
+)
+
+var StakedropAddressCmd = &cli.Command{
+	Name:   "stakedrop-address",
+	Usage:  "update the claims address for an operator in the season 2 stakedrop",
+	Action: handleStakedropAddress,
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:     "operator-id",
+			Usage:    "Operator ID",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "claim-address",
+			Usage:    "Address the operator wishes to claim with",
+			Required: true,
+		},
+	},
+}
+
+func handleStakedropAddress(ctx context.Context, cmd *cli.Command) error {
+
+	// parse cli input
+	operatorID := cmd.Int("operator-id")
+	claimAddress := common.HexToAddress(cmd.String("claim-address"))
+
+	// try to load RPC_URL from env or flags
+	rpcURL := os.Getenv("RPC_URL")
+	if cmd.String("rpc-url") != "" {
+		rpcURL = cmd.String("rpc-url")
+	}
+	if rpcURL == "" {
+		return fmt.Errorf("must set env var $RPC_URL or use --rpc-url flag")
+	}
+	rpcClient, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		return fmt.Errorf("dialing RPC: %w", err)
+	}
+
+	// load all required addresses for this chain
+	cfg, err := config.AutodetectConfig(rpcClient)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	etherfiAPI := etherfi.New(cfg, rpcClient)
+
+	// look up operator contract associated with this id
+	operator, err := etherfiAPI.LookupOperatorByID(operatorID)
+	if err != nil {
+		return fmt.Errorf("looking up operator address: %w", err)
+	}
+
+	return eigenlayer.RegisterClaimAddressForOperator(operator, claimAddress)
+}

--- a/src/avs/lagrangeSC/lagrange.go
+++ b/src/avs/lagrangeSC/lagrange.go
@@ -3,7 +3,6 @@ package lagrangesc
 import (
 	"crypto/ecdsa"
 	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"time"
@@ -71,8 +70,6 @@ func (a *API) PrepareRegistration(operator *etherfi.Operator, signerAddr common.
 	blsPrivKey := blsKey.PrivKey.Text(16)
 	blsPrivKeys := []string{blsPrivKey}
 
-	fmt.Printf("pubkey: %s\n", hex.EncodeToString(blsKey.PubKey.Serialize()))
-
 	g1Pubkeys, g2Pubkey, sig, err := lagrangeutils.GenerateBLSSignature(keyWithProofDigest[:], blsPrivKeys...)
 	if err != nil {
 		fmt.Errorf("generating aggregate BLS signature: %w", err)
@@ -104,17 +101,6 @@ func (a *API) RegisterOperator(operator *etherfi.Operator, info RegistrationInfo
 		Signature: sigWithSaltAndExpiry.Signature,
 		Salt:      sigWithSaltAndExpiry.Salt,
 		Expiry:    sigWithSaltAndExpiry.Expiry,
-	}
-
-	for _, x := range info.BLSKeyWithProof.BlsG1PublicKeys {
-		for _, y := range x {
-			fmt.Printf("%s\n", y.Text(16))
-		}
-	}
-	for _, x := range info.BLSKeyWithProof.AggG2PublicKey {
-		for _, y := range x {
-			fmt.Printf("%s\n", y.Text(16))
-		}
 	}
 
 	// manually pack tx data since we are submitting via gnosis instead of directly
@@ -174,19 +160,6 @@ func (a *API) SubscribeToChains(operator *etherfi.Operator, chainIDs []int64) er
 }
 
 func (a *API) UpdateBLSPubkey(operator *etherfi.Operator, info RegistrationInfo) error {
-
-	fmt.Println("G1")
-	for _, x := range info.BLSKeyWithProof.BlsG1PublicKeys {
-		for _, y := range x {
-			fmt.Printf("%s\n", y.Text(16))
-		}
-	}
-	fmt.Println("G2")
-	for _, x := range info.BLSKeyWithProof.AggG2PublicKey {
-		for _, y := range x {
-			fmt.Printf("%s\n", y.Text(16))
-		}
-	}
 
 	keyIndex := uint32(0)
 

--- a/src/config/chainconfig.go
+++ b/src/config/chainconfig.go
@@ -17,6 +17,9 @@ type Config struct {
 	StrategyManagerAddress   common.Address
 	EigenpodManagerAddress   common.Address
 
+	// additional Eigenlayer contracts
+	EigenlayerOperatorRegistryClaimAddress common.Address // for updating stakedrop claims for operator contracts
+
 	// strategies (how eigenlayer tracks different LRT's + beacon eth)
 	BeaconEthStrategyAddress common.Address
 	WethStrategyAddress      common.Address
@@ -82,6 +85,8 @@ var Mainnet = Config{
 	EigenpodManagerAddress:   common.HexToAddress("0x91E677b07F7AF907ec9a428aafA9fc14a0d3A338"),
 	BeaconEthStrategyAddress: common.HexToAddress("0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0"),
 	WethStrategyAddress:      common.HexToAddress(""),
+
+	EigenlayerOperatorRegistryClaimAddress: common.HexToAddress("0x8bB56D1CBA6273478E9B4D79F89857ac8D766eb3"),
 
 	AvsOperatorManagerAddress: common.HexToAddress("0x2093Bbb221f1d8C7c932c32ee28Be6dEe4a37A6a"),
 

--- a/src/eigenlayer/operator_registry.abi
+++ b/src/eigenlayer/operator_registry.abi
@@ -1,0 +1,39 @@
+[
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operator",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "registeredWallet",
+                "type": "address"
+            }
+        ],
+        "name": "Registered",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "registeredWallet",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "operatorMessage",
+                "type": "string"
+            }
+        ],
+        "name": "Register",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/src/eigenlayer/operator_registry.go
+++ b/src/eigenlayer/operator_registry.go
@@ -1,0 +1,355 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package eigenlayer
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// OperatorRegistryMetaData contains all meta data concerning the OperatorRegistry contract.
+var OperatorRegistryMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"registeredWallet\",\"type\":\"address\"}],\"name\":\"Registered\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"registeredWallet\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"operatorMessage\",\"type\":\"string\"}],\"name\":\"Register\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// OperatorRegistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use OperatorRegistryMetaData.ABI instead.
+var OperatorRegistryABI = OperatorRegistryMetaData.ABI
+
+// OperatorRegistry is an auto generated Go binding around an Ethereum contract.
+type OperatorRegistry struct {
+	OperatorRegistryCaller     // Read-only binding to the contract
+	OperatorRegistryTransactor // Write-only binding to the contract
+	OperatorRegistryFilterer   // Log filterer for contract events
+}
+
+// OperatorRegistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type OperatorRegistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OperatorRegistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type OperatorRegistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OperatorRegistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type OperatorRegistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OperatorRegistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type OperatorRegistrySession struct {
+	Contract     *OperatorRegistry // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// OperatorRegistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type OperatorRegistryCallerSession struct {
+	Contract *OperatorRegistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// OperatorRegistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type OperatorRegistryTransactorSession struct {
+	Contract     *OperatorRegistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// OperatorRegistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type OperatorRegistryRaw struct {
+	Contract *OperatorRegistry // Generic contract binding to access the raw methods on
+}
+
+// OperatorRegistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type OperatorRegistryCallerRaw struct {
+	Contract *OperatorRegistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// OperatorRegistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type OperatorRegistryTransactorRaw struct {
+	Contract *OperatorRegistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewOperatorRegistry creates a new instance of OperatorRegistry, bound to a specific deployed contract.
+func NewOperatorRegistry(address common.Address, backend bind.ContractBackend) (*OperatorRegistry, error) {
+	contract, err := bindOperatorRegistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &OperatorRegistry{OperatorRegistryCaller: OperatorRegistryCaller{contract: contract}, OperatorRegistryTransactor: OperatorRegistryTransactor{contract: contract}, OperatorRegistryFilterer: OperatorRegistryFilterer{contract: contract}}, nil
+}
+
+// NewOperatorRegistryCaller creates a new read-only instance of OperatorRegistry, bound to a specific deployed contract.
+func NewOperatorRegistryCaller(address common.Address, caller bind.ContractCaller) (*OperatorRegistryCaller, error) {
+	contract, err := bindOperatorRegistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OperatorRegistryCaller{contract: contract}, nil
+}
+
+// NewOperatorRegistryTransactor creates a new write-only instance of OperatorRegistry, bound to a specific deployed contract.
+func NewOperatorRegistryTransactor(address common.Address, transactor bind.ContractTransactor) (*OperatorRegistryTransactor, error) {
+	contract, err := bindOperatorRegistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OperatorRegistryTransactor{contract: contract}, nil
+}
+
+// NewOperatorRegistryFilterer creates a new log filterer instance of OperatorRegistry, bound to a specific deployed contract.
+func NewOperatorRegistryFilterer(address common.Address, filterer bind.ContractFilterer) (*OperatorRegistryFilterer, error) {
+	contract, err := bindOperatorRegistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &OperatorRegistryFilterer{contract: contract}, nil
+}
+
+// bindOperatorRegistry binds a generic wrapper to an already deployed contract.
+func bindOperatorRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := OperatorRegistryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_OperatorRegistry *OperatorRegistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _OperatorRegistry.Contract.OperatorRegistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_OperatorRegistry *OperatorRegistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OperatorRegistry.Contract.OperatorRegistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_OperatorRegistry *OperatorRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _OperatorRegistry.Contract.OperatorRegistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_OperatorRegistry *OperatorRegistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _OperatorRegistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_OperatorRegistry *OperatorRegistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OperatorRegistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_OperatorRegistry *OperatorRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _OperatorRegistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x6ba0831d.
+//
+// Solidity: function Register(address registeredWallet, string operatorMessage) returns()
+func (_OperatorRegistry *OperatorRegistryTransactor) Register(opts *bind.TransactOpts, registeredWallet common.Address, operatorMessage string) (*types.Transaction, error) {
+	return _OperatorRegistry.contract.Transact(opts, "Register", registeredWallet, operatorMessage)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x6ba0831d.
+//
+// Solidity: function Register(address registeredWallet, string operatorMessage) returns()
+func (_OperatorRegistry *OperatorRegistrySession) Register(registeredWallet common.Address, operatorMessage string) (*types.Transaction, error) {
+	return _OperatorRegistry.Contract.Register(&_OperatorRegistry.TransactOpts, registeredWallet, operatorMessage)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x6ba0831d.
+//
+// Solidity: function Register(address registeredWallet, string operatorMessage) returns()
+func (_OperatorRegistry *OperatorRegistryTransactorSession) Register(registeredWallet common.Address, operatorMessage string) (*types.Transaction, error) {
+	return _OperatorRegistry.Contract.Register(&_OperatorRegistry.TransactOpts, registeredWallet, operatorMessage)
+}
+
+// OperatorRegistryRegisteredIterator is returned from FilterRegistered and is used to iterate over the raw logs and unpacked data for Registered events raised by the OperatorRegistry contract.
+type OperatorRegistryRegisteredIterator struct {
+	Event *OperatorRegistryRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OperatorRegistryRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OperatorRegistryRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OperatorRegistryRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OperatorRegistryRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OperatorRegistryRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OperatorRegistryRegistered represents a Registered event raised by the OperatorRegistry contract.
+type OperatorRegistryRegistered struct {
+	Operator         common.Address
+	RegisteredWallet common.Address
+	Raw              types.Log // Blockchain specific contextual infos
+}
+
+// FilterRegistered is a free log retrieval operation binding the contract event 0x0a31ee9d46a828884b81003c8498156ea6aa15b9b54bdd0ef0b533d9eba57e55.
+//
+// Solidity: event Registered(address indexed operator, address indexed registeredWallet)
+func (_OperatorRegistry *OperatorRegistryFilterer) FilterRegistered(opts *bind.FilterOpts, operator []common.Address, registeredWallet []common.Address) (*OperatorRegistryRegisteredIterator, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var registeredWalletRule []interface{}
+	for _, registeredWalletItem := range registeredWallet {
+		registeredWalletRule = append(registeredWalletRule, registeredWalletItem)
+	}
+
+	logs, sub, err := _OperatorRegistry.contract.FilterLogs(opts, "Registered", operatorRule, registeredWalletRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OperatorRegistryRegisteredIterator{contract: _OperatorRegistry.contract, event: "Registered", logs: logs, sub: sub}, nil
+}
+
+// WatchRegistered is a free log subscription operation binding the contract event 0x0a31ee9d46a828884b81003c8498156ea6aa15b9b54bdd0ef0b533d9eba57e55.
+//
+// Solidity: event Registered(address indexed operator, address indexed registeredWallet)
+func (_OperatorRegistry *OperatorRegistryFilterer) WatchRegistered(opts *bind.WatchOpts, sink chan<- *OperatorRegistryRegistered, operator []common.Address, registeredWallet []common.Address) (event.Subscription, error) {
+
+	var operatorRule []interface{}
+	for _, operatorItem := range operator {
+		operatorRule = append(operatorRule, operatorItem)
+	}
+	var registeredWalletRule []interface{}
+	for _, registeredWalletItem := range registeredWallet {
+		registeredWalletRule = append(registeredWalletRule, registeredWalletItem)
+	}
+
+	logs, sub, err := _OperatorRegistry.contract.WatchLogs(opts, "Registered", operatorRule, registeredWalletRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OperatorRegistryRegistered)
+				if err := _OperatorRegistry.contract.UnpackLog(event, "Registered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRegistered is a log parse operation binding the contract event 0x0a31ee9d46a828884b81003c8498156ea6aa15b9b54bdd0ef0b533d9eba57e55.
+//
+// Solidity: event Registered(address indexed operator, address indexed registeredWallet)
+func (_OperatorRegistry *OperatorRegistryFilterer) ParseRegistered(log types.Log) (*OperatorRegistryRegistered, error) {
+	event := new(OperatorRegistryRegistered)
+	if err := _OperatorRegistry.contract.UnpackLog(event, "Registered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/src/eigenlayer/stakedrop.go
+++ b/src/eigenlayer/stakedrop.go
@@ -1,0 +1,37 @@
+package eigenlayer
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/config"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/etherfi"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/gnosis"
+	"github.com/etherfi-protocol/etherfi-avs-operator-tool/src/utils"
+)
+
+func RegisterClaimAddressForOperator(operator *etherfi.Operator, claimAddress common.Address) error {
+
+	// must send tx with this exact message
+	msg := "I agree to have my operator EIGEN allocation be claimed from the registered wallet in this transaction."
+
+	// manually pack tx data since we are submitting via gnosis instead of directly
+	operatorRegistryABI, err := OperatorRegistryMetaData.GetAbi()
+	if err != nil {
+		return fmt.Errorf("fetching abi: %w", err)
+	}
+	calldata, err := operatorRegistryABI.Pack("Register", claimAddress, msg)
+	if err != nil {
+		return fmt.Errorf("packing input: %w", err)
+	}
+
+	// wrap the inner call to be forwarded via AvsOperatorManager
+	adminCall, err := utils.PackForwardCallForAdmin(operator.ID, calldata, config.Mainnet.EigenlayerOperatorRegistryClaimAddress)
+	if err != nil {
+		return fmt.Errorf("wrapping call for admin: %w", err)
+	}
+
+	// output in gnosis compatible format
+	batch := gnosis.NewSingleTxBatch(adminCall, config.Mainnet.AvsOperatorManagerAddress, fmt.Sprintf("stakedrop-claim-address-%d", operator.ID))
+	return utils.ExportJSON("stakedrop-claim-address", operator.ID, batch)
+}


### PR DESCRIPTION
This PR adds 3 small commands to the cli

1. `lagrangeSC update-bls-pubkey` During the registration process, the bls key was accidentally truncated resulting in the wrong key being registered. This command lets us fix the registered pubkey
2. `stakedrop-address` allows the admin to set the claim address for a target operator for eigenlayer's stakedrop
3. `registration-status` tells you all the AVS's that a target operator is registered for