### PR TITLE
docs: Ungate admin flow documents the `alignedlayer` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ and note the address of the key you generated
 1. Receive prepared registration json file from target node operator
 2. Register the operator contract
 
-           ./avs-cli alignedlayer register --registration-input input.json
+           ./avs-cli ungate register --operator-id {operator_id} --othentic-output {path_to_othentic_output}
 
            // submit resulting output as a gnosis TX via AVS admin gnosis
 


### PR DESCRIPTION
## Problem

`README.md:141`, under **# Ungate → ## Ether.fi Admin Flow**, tells the admin to run:

```
./avs-cli alignedlayer register --registration-input input.json
```

That is the Aligned Layer command copied verbatim from line 70. Following it registers against the wrong AVS — and in fact it cannot run at all, because the flag is wrong too.

`bin/avs-cli/ungate/ungate.go:61` defines the real command:

```go
var RegisterCmd = &cli.Command{
	Name:   "register",
	Usage:  "(Admin) Register target operator to the AVS",
	Flags: []cli.Flag{
		&cli.IntFlag{    Name: "operator-id",      Required: true },
		&cli.StringFlag{ Name: "othentic-output",  Required: true },
	},
}
```

So `ungate register` takes `--operator-id` and `--othentic-output`; there is no `--registration-input` flag on it. Both required flags are missing from the documented line.

`--othentic-output` is also the consistent one: the Ungate **Operator Flow** just above tells the operator to generate their artifact with Othentic's tooling, and `handleRegister` reads that file.

## Fix

```
./avs-cli ungate register --operator-id {operator_id} --othentic-output {path_to_othentic_output}
```

One line. The Aligned Layer occurrence at line 70 is correct and untouched, as are the `gasp` and `predicate` sections — those subcommands really do take `--registration-input`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/etherfi-protocol/codesmith/etherfi-avs-operator-CLI/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788902973&installation_model_id=18424&pr_number=50&repository=etherfi-protocol%2Fetherfi-avs-operator-CLI&return_to=https%3A%2F%2Fgithub.com%2Fetherfi-protocol%2Fetherfi-avs-operator-CLI%2Fpull%2F50&signature=312557fac53a4c4ed730645e69880e5780acf6e0d88ec04c90410505deb6e7a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->